### PR TITLE
13: Rewrite SYCL stencil using USM

### DIFF
--- a/content/13-examples.rst
+++ b/content/13-examples.rst
@@ -288,7 +288,8 @@ GPU parallelization: first steps
 
 Let's apply several techniques presented in previous episodes to make stencil update GPU-parallel.
 
-OpenMP (or OpenACC) offloading requires to define a region to be executed in parallel as well as data that shall be copied over/ used in GPU memory. Similarly, SYCL programming model offers convenient ways to define execution kernels, context to run them in (called queue) and simplified CPU-GPU transfer of needed data.
+OpenMP (or OpenACC) offloading requires to define a region to be executed in parallel as well as data that shall be copied over/ used in GPU memory.
+Similarly, SYCL programming model offers convenient ways to define execution kernels, context to run them in (called queue). However, for better control over data movement, we use manual memory allocation and movement.
 
 Changes of stencil update code for OpenMP and SYCL are shown in the tabs below:
 
@@ -304,7 +305,7 @@ Changes of stencil update code for OpenMP and SYCL are shown in the tabs below:
 
          .. literalinclude:: examples/stencil/sycl/core-naive.cpp 
                         :language: cpp
-                        :emphasize-lines: 31,35
+                        :emphasize-lines: 24-27,29,43-45
 
 .. callout:: Loading modules on LUMI
    
@@ -398,7 +399,7 @@ Changes of stencil update code as well as the main program are shown in tabs bel
 
          .. literalinclude:: examples/stencil/sycl/core.cpp
                         :language: cpp
-                        :emphasize-lines: 13-14,27-28,41-55
+                        :emphasize-lines: 13-14,25,40-50
 
    .. tab:: Python
 
@@ -411,7 +412,7 @@ Changes of stencil update code as well as the main program are shown in tabs bel
 
          .. literalinclude:: examples/stencil/sycl/main.cpp 
                         :language: cpp
-                        :emphasize-lines: 38-39,44-45,51,56,59,75
+                        :emphasize-lines: 38-39,44-45,51,56,59,75-77
 
 .. challenge:: Exercise: updated GPU ports
 

--- a/content/examples/stencil/sycl/heat.h
+++ b/content/examples/stencil/sycl/heat.h
@@ -41,7 +41,7 @@ void initialize(int argc, char *argv[], field *heat1,
 
 void evolve(sycl::queue &Q, field *curr, field *prev, double a, double dt);
 
-void evolve(sycl::queue &Q, sycl::buffer<double, 2> buf_curr, sycl::buffer<double, 2> buf_prev, 
+void evolve(sycl::queue &Q, double* buf_curr, const double* buf_prev, 
             const field *prev, double a, double dt);
 
 void field_set_size(field *heat, int nx, int ny);
@@ -61,8 +61,8 @@ void field_swap(field *heat1, field *heat2);
 void field_allocate(field *heat);
 
 // Data movement function prototypes
-void copy_to_buffer(sycl::queue Q, sycl::buffer<double, 2> buffer, const field* f);
+void copy_to_buffer(sycl::queue Q, double* buffer, const field* f);
 
-void copy_from_buffer(sycl::queue Q, sycl::buffer<double, 2> buffer, field *f);
+void copy_from_buffer(sycl::queue Q, const double* buffer, field *f);
 
 #endif  // __HEAT_H__

--- a/content/examples/stencil/sycl/main-naive.cpp
+++ b/content/examples/stencil/sycl/main-naive.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     // Set output interval
     int output_interval = 1500;
 
-    sycl::queue Q;
+    sycl::queue Q{sycl::property::queue::in_order()};
 
     // Start timer
     auto start_clock = start_time();

--- a/content/examples/stencil/sycl/main.cpp
+++ b/content/examples/stencil/sycl/main.cpp
@@ -32,11 +32,11 @@ int main(int argc, char **argv)
     // Set output interval
     int output_interval = 1500;
 
-    sycl::queue Q;
+    sycl::queue Q{sycl::property::queue::in_order()};
 
     // Create two identical device buffers
-    const sycl::range<2> buffer_size{ size_t(current.nx + 2), size_t(current.ny + 2) };
-    sycl::buffer<double, 2> d_current{buffer_size}, d_previous{buffer_size};
+    double *d_current = sycl::malloc_device<double>((current.nx + 2) * (current.ny + 2), Q);
+    double *d_previous = sycl::malloc_device<double>((current.nx + 2) * (current.ny + 2), Q);
 
     // Start timer
     auto start_clock = start_time();
@@ -73,5 +73,7 @@ int main(int argc, char **argv)
     std::chrono::duration<double> elapsed = stop_clock - start_clock;
     printf("Iterations took %.3f seconds.\n", elapsed.count());
     Q.wait_and_throw();
+    sycl::free(d_previous, Q);
+    sycl::free(d_current, Q);
     return 0;
 }


### PR DESCRIPTION
Switching the example from buffers to USM, because:

- USM is closer to how CUDA/HIP work, so added educational value, 
- more relevant for the HPC community, since buffers are, in practice, slower (even on this example),
- should not suffer from the segfault seen on LUMI (presumably, something in ACpp runtime),
- should have predictable performance regardless of how many CPUs/GPUs are available.

The only downside is that the code is a bit more verbose.