### PR TITLE
Update 8-portable-kernel-models.rst

### DIFF
--- a/content/8-portable-kernel-models.rst
+++ b/content/8-portable-kernel-models.rst
@@ -38,7 +38,7 @@ StdPar compilation
 
 The build process depends a lot on the used compiler:
 
-- AdaptiveCpp: Add ``-acpp-stdpar`` flag when calling ``acpp``.
+- AdaptiveCpp: Add ``--acpp-stdpar`` flag when calling ``acpp``.
 - Intel oneAPI: Add ``-fsycl -fsycl-pstl-offload=gpu`` flags when calling ``icpx``.
 - NVIDIA NVC++: Add ``-stdpar`` flag when calling ``nvc++`` (not supported with plain ``nvcc``).
 


### PR DESCRIPTION
It should be ``--acpp-stdpar`` instead of ``-acpp-stdpar``